### PR TITLE
Use polling delay for exceptional cases.

### DIFF
--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/frameworks/CoinMovementMonitor.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/frameworks/CoinMovementMonitor.kt
@@ -45,7 +45,8 @@ class CoinMovementMonitor(
                 } catch (t: Throwable) {
                     log.warn("Could not send batch", t)
 
-                    Thread.sleep(30 * 1_000L)
+                    // Thread.sleep(30 * 1_000L)
+                    Thread.sleep(pollingDelayMillis)
                 }
             }
         }


### PR DESCRIPTION
Temporary change to suppress the error logs while we work out the http/https redirect.