### PR TITLE
Movement improvements

### DIFF
--- a/database/src/main/resources/db/migration/V5_0__change_coin_movement_pk.sql
+++ b/database/src/main/resources/db/migration/V5_0__change_coin_movement_pk.sql
@@ -1,0 +1,9 @@
+ALTER TABLE coin_movement ADD COLUMN txid_v2 TEXT;
+UPDATE coin_movement SET txid_v2 = (
+	SELECT txid FROM coin_movement other
+		WHERE coin_movement.txid = other.txid
+) || '-0';
+ALTER TABLE coin_movement DROP CONSTRAINT coin_movement_pkey;
+ALTER TABLE coin_movement ALTER COLUMN txid DROP NOT NULL;
+ALTER TABLE coin_movement ALTER COLUMN txid_v2 SET NOT NULL;
+ALTER TABLE coin_movement ADD PRIMARY KEY (txid_v2);

--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/domain/CoinMovement.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/domain/CoinMovement.kt
@@ -54,17 +54,18 @@ open class CoinMovementEntityClass : StringEntityClass<CoinMovementRecord>(CoinM
         amount: String,
         denom: String,
         type: String,
-    ) = findById(txHash) ?: new(txHash) {
-        this.fromAddress = fromAddress
-        this.fromAddressBankUuid = fromAddressBankUuid
-        this.toAddress = toAddress
-        this.toAddressBankUuid = toAddressBankUuid
-        this.blockHeight = blockHeight
-        this.blockTime = blockTime
-        this.amount = amount
-        this.denom = denom
-        this.type = type
-        this.created = OffsetDateTime.now()
+    ) = CoinMovementTable.upsertDoNothing("coin_movement_pkey") {
+        it[id] = txHash
+        it[this.fromAddress] = fromAddress
+        it[this.fromAddressBankUuid] = fromAddressBankUuid
+        it[this.toAddress] = toAddress
+        it[this.toAddressBankUuid] = toAddressBankUuid
+        it[this.blockHeight] = blockHeight
+        it[this.blockTime] = blockTime
+        it[this.amount] = amount
+        it[this.denom] = denom
+        it[this.type] = type
+        it[this.created] = OffsetDateTime.now()
     }
 }
 

--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/domain/CoinMovement.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/domain/CoinMovement.kt
@@ -23,7 +23,8 @@ open class StringIdTable(name: String, columnName: String = "id") : IdTable<Stri
     override val primaryKey by lazy { super.primaryKey ?: PrimaryKey(id) }
 }
 
-object CoinMovementTable : StringIdTable(name = "coin_movement", columnName = "txid") {
+object CoinMovementTable : StringIdTable(name = "coin_movement", columnName = "txid_v2") {
+    val legacyTxHash = text("txid").nullable()
     val fromAddress = text("from_addr")
     val fromAddressBankUuid = uuid("from_addr_bank_uuid").nullable()
     val toAddress = text("to_addr")
@@ -70,7 +71,8 @@ open class CoinMovementEntityClass : StringEntityClass<CoinMovementRecord>(CoinM
 class CoinMovementRecord(id: EntityID<String>) : Entity<String>(id) {
     companion object : CoinMovementEntityClass()
 
-    var txHash by CoinMovementTable.id
+    var _txHashV2 by CoinMovementTable.id
+    var _txHash by CoinMovementTable.legacyTxHash
     var fromAddress by CoinMovementTable.fromAddress
     var fromAddressBankUuid by CoinMovementTable.fromAddressBankUuid
     var toAddress by CoinMovementTable.toAddress
@@ -81,4 +83,6 @@ class CoinMovementRecord(id: EntityID<String>) : Entity<String>(id) {
     var denom by CoinMovementTable.denom
     var type by CoinMovementTable.type
     var created by CoinMovementTable.created
+
+    fun txHash(): String = _txHash ?: _txHashV2.value
 }

--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/domain/Utils.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/domain/Utils.kt
@@ -1,0 +1,27 @@
+package io.provenance.digitalcurrency.consortium.domain
+
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.statements.InsertStatement
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+
+class InsertUpdateOnConflictDoNothing<T : Any>(
+    private val constraint: String?,
+    table: Table,
+    isIgnore: Boolean = false // does nothing on postgres dialect
+) : InsertStatement<T>(table, isIgnore) {
+
+    override fun prepareSQL(transaction: Transaction): String {
+        val conflict = "ON CONFLICT ${constraint?.let { "ON CONSTRAINT \"$it\"" }} DO NOTHING"
+        return "${super.prepareSQL(transaction)} $conflict"
+    }
+}
+
+fun <T : Table> T.upsertDoNothing(
+    constraint: String?,
+    body: T.(InsertStatement<ResultRow>) -> Unit
+) = InsertUpdateOnConflictDoNothing<ResultRow>(constraint, this).apply {
+    body(this)
+    execute(TransactionManager.current())
+}

--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/frameworks/CoinMovementMonitor.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/frameworks/CoinMovementMonitor.kt
@@ -58,7 +58,7 @@ class CoinMovementMonitor(
 
         log.info("starting coin movement push with boundaries [$bookmark, $endBlock]")
 
-        val request = transaction { CoinMovementRecord.findBatch(bookmark, endBlock) }.toOutput()
+        val request = transaction { CoinMovementRecord.findBatch(bookmark, endBlock).toOutput() }
 
         log.debug("sending batch $request")
 
@@ -72,7 +72,7 @@ fun List<CoinMovementRecord>.toOutput() = CoinMovementRequest(
     recordCount = this.size,
     transactions = this.map { coinMovement ->
         CoinMovementRequestItem(
-            txId = coinMovement.txHash.value,
+            txId = coinMovement.txHash(),
             fromAddress = coinMovement.fromAddress,
             fromAddressBankUuid = coinMovement.fromAddressBankUuid,
             toAddress = coinMovement.toAddress,

--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/service/AddressTagService.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/service/AddressTagService.kt
@@ -19,7 +19,7 @@ class AddressTagService(
     fun createEvent(addressRegistrationRecord: AddressRegistrationRecord) {
         val existing =
             pbcService.getAttributeByTagName(addressRegistrationRecord.address, bankClientProperties.kycTagName)
-        when (existing.isEmpty()) {
+        when (existing == null) {
             true -> {
                 try {
                     pbcService.addAttribute(
@@ -45,7 +45,7 @@ class AddressTagService(
     fun eventComplete(addressRegistrationRecord: AddressRegistrationRecord) {
         val existing =
             pbcService.getAttributeByTagName(addressRegistrationRecord.address, bankClientProperties.kycTagName)
-        when (existing.isEmpty()) {
+        when (existing == null) {
             true -> {
                 val response = pbcService.getTransaction(addressRegistrationRecord.txHash!!)
                 if (response == null || response.txResponse.isFailed()) {

--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/service/PbcService.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/service/PbcService.kt
@@ -69,8 +69,8 @@ class PbcService(
     fun getAttributes(address: String): List<Attribute> =
         grpcClientService.new().attributes.getAllAttributes(address)
 
-    fun getAttributeByTagName(address: String, tag: String): List<Attribute> =
-        getAttributes(address).filter { it.name == tag }
+    fun getAttributeByTagName(address: String, tag: String): Attribute? =
+        getAttributes(address).find { it.name == tag }
 
     fun addAttribute(address: String, tag: String, payload: ByteString) =
         grpcClientService.new().estimateAndBroadcastTx(

--- a/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/config/AppConfigTest.kt
+++ b/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/config/AppConfigTest.kt
@@ -10,10 +10,4 @@ class AppConfigTest {
 
     @Bean
     fun eventStreamFactory(): EventStreamFactory = mock()
-
-    // @Bean
-    // fun pbcService(): PbcService = mock()
-
-    // @Bean
-    // fun rpcClient(): RpcClient = mock()
 }

--- a/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/service/AddressTagServiceTest.kt
+++ b/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/service/AddressTagServiceTest.kt
@@ -67,7 +67,7 @@ class AddressTagServiceTest : DatabaseTest() {
                     TEST_ADDRESS,
                     bankClientProperties.kycTagName
                 )
-            ).thenReturn(listOf())
+            ).thenReturn(null)
             whenever(
                 pbcService.addAttribute(
                     TEST_ADDRESS, bankClientProperties.kycTagName,
@@ -106,13 +106,11 @@ class AddressTagServiceTest : DatabaseTest() {
             val registration = transaction { insertRegisteredAddress(uuid, TEST_ADDRESS) }
 
             whenever(pbcService.getAttributeByTagName(TEST_ADDRESS, bankClientProperties.kycTagName)).thenReturn(
-                listOf(
-                    Attribute
-                        .newBuilder()
-                        .setAddress(TEST_ADDRESS)
-                        .setName(bankClientProperties.kycTagName)
-                        .build()
-                )
+                Attribute
+                    .newBuilder()
+                    .setAddress(TEST_ADDRESS)
+                    .setName(bankClientProperties.kycTagName)
+                    .build()
             )
 
             transaction {
@@ -140,9 +138,7 @@ class AddressTagServiceTest : DatabaseTest() {
             val uuid = UUID.randomUUID()
             val registration = transaction { insertRegisteredAddress(uuid, TEST_ADDRESS) }
 
-            whenever(pbcService.getAttributeByTagName(TEST_ADDRESS, bankClientProperties.kycTagName)).thenReturn(
-                listOf()
-            )
+            whenever(pbcService.getAttributeByTagName(TEST_ADDRESS, bankClientProperties.kycTagName)).thenReturn(null)
 
             whenever(
                 pbcService.addAttribute(
@@ -192,13 +188,11 @@ class AddressTagServiceTest : DatabaseTest() {
                     bankClientProperties.kycTagName
                 )
             ).thenReturn(
-                listOf(
-                    Attribute
-                        .newBuilder()
-                        .setAddress(TEST_ADDRESS)
-                        .setName(bankClientProperties.kycTagName)
-                        .build()
-                )
+                Attribute
+                    .newBuilder()
+                    .setAddress(TEST_ADDRESS)
+                    .setName(bankClientProperties.kycTagName)
+                    .build()
             )
 
             transaction {
@@ -228,9 +222,7 @@ class AddressTagServiceTest : DatabaseTest() {
                 }
             }
 
-            whenever(pbcService.getAttributeByTagName(TEST_ADDRESS, bankClientProperties.kycTagName)).thenReturn(
-                listOf()
-            )
+            whenever(pbcService.getAttributeByTagName(TEST_ADDRESS, bankClientProperties.kycTagName)).thenReturn(null)
 
             whenever(pbcService.getTransaction(txHash)).thenReturn(getTransactionResponse(txHash))
 
@@ -261,9 +253,7 @@ class AddressTagServiceTest : DatabaseTest() {
                 }
             }
 
-            whenever(pbcService.getAttributeByTagName(TEST_ADDRESS, bankClientProperties.kycTagName)).thenReturn(
-                listOf()
-            )
+            whenever(pbcService.getAttributeByTagName(TEST_ADDRESS, bankClientProperties.kycTagName)).thenReturn(null)
 
             whenever(pbcService.getTransaction(txHash)).thenReturn(null)
 
@@ -296,9 +286,7 @@ class AddressTagServiceTest : DatabaseTest() {
                 }
             }
 
-            whenever(pbcService.getAttributeByTagName(TEST_ADDRESS, bankClientProperties.kycTagName)).thenReturn(
-                listOf()
-            )
+            whenever(pbcService.getAttributeByTagName(TEST_ADDRESS, bankClientProperties.kycTagName)).thenReturn(null)
 
             whenever(pbcService.getTransaction(txHash)).thenReturn(getErrorTransactionResponse(txHash))
 

--- a/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
+++ b/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
@@ -336,18 +336,6 @@ class EventStreamConsumerTest {
     fun `coinMovement - check v1 vs v2 output`() {
         transaction {
             CoinMovementRecord.insert(
-                txHash = "abc",
-                fromAddress = "fromAddress",
-                fromAddressBankUuid = null,
-                toAddress = "toAddress",
-                toAddressBankUuid = null,
-                blockHeight = 0,
-                blockTime = OffsetDateTime.now(),
-                amount = "100",
-                denom = "coin",
-                type = "MINT",
-            )
-            CoinMovementRecord.insert(
                 txHash = "abc-0",
                 fromAddress = "fromAddress",
                 fromAddressBankUuid = null,
@@ -366,6 +354,18 @@ class EventStreamConsumerTest {
         }
 
         transaction {
+            CoinMovementRecord.insert(
+                txHash = "abc-0",
+                fromAddress = "fromAddress",
+                fromAddressBankUuid = null,
+                toAddress = "toAddress",
+                toAddressBankUuid = null,
+                blockHeight = 0,
+                blockTime = OffsetDateTime.now(),
+                amount = "100",
+                denom = "coin",
+                type = "MINT",
+            )
             CoinMovementRecord.insert(
                 txHash = "xyz-0",
                 fromAddress = "fromAddress",
@@ -416,13 +416,13 @@ class EventStreamConsumerTest {
             )
         }
 
-        Assertions.assertEquals(5, transaction { CoinMovementRecord.all().count() })
+        Assertions.assertEquals(4, transaction { CoinMovementRecord.all().count() })
         Assertions.assertArrayEquals(
-            listOf("abc", "abc-0", "xyz-0", "xyz-1", "xyz-2").toTypedArray(),
+            listOf("abc-0", "xyz-0", "xyz-1", "xyz-2").toTypedArray(),
             transaction { CoinMovementRecord.all().toList() }.map { it._txHashV2.value }.sorted().toTypedArray(),
         )
         Assertions.assertArrayEquals(
-            listOf("abc", "abc", "xyz-0", "xyz-1", "xyz-2").toTypedArray(),
+            listOf("abc", "xyz-0", "xyz-1", "xyz-2").toTypedArray(),
             transaction { CoinMovementRecord.all().toList() }.toOutput().transactions.map { it.txId }.sorted().toTypedArray(),
         )
     }

--- a/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
+++ b/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
@@ -1,292 +1,429 @@
 package io.provenance.digitalcurrency.consortium.stream
 
-// import com.google.protobuf.ByteString
-// import io.mockk.every
-// import io.mockk.mockkStatic
-// import io.provenance.attribute.v1.Attribute
-// import io.provenance.digitalcurrency.consortium.TestContainer
-// import io.provenance.digitalcurrency.consortium.config.BankClientProperties
-// import io.provenance.digitalcurrency.consortium.config.EventStreamProperties
-// import io.provenance.digitalcurrency.consortium.config.ProvenanceProperties
-// import io.provenance.digitalcurrency.consortium.config.ServiceProperties
-// import io.provenance.digitalcurrency.consortium.domain.CoinMovementRecord
-// import io.provenance.digitalcurrency.consortium.extension.toByteArray
-// import io.provenance.digitalcurrency.consortium.pbclient.RpcClient
-// import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockId
-// import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockResponse
-// import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.PartSetHeader
-// import io.provenance.digitalcurrency.consortium.pbclient.fetchBlock
-// import io.provenance.digitalcurrency.consortium.randomTxHash
-// import io.provenance.digitalcurrency.consortium.service.PbcService
-// import org.jetbrains.exposed.sql.transactions.transaction
-// import org.junit.jupiter.api.Assertions
-// import org.junit.jupiter.api.BeforeAll
-// import org.junit.jupiter.api.BeforeEach
-// import org.junit.jupiter.api.Test
-// import org.mockito.kotlin.any
-// import org.mockito.kotlin.reset
-// import org.mockito.kotlin.whenever
-// import org.springframework.beans.factory.annotation.Autowired
-// import org.springframework.boot.test.mock.mockito.MockBean
-// import java.time.OffsetDateTime
-// import java.util.UUID
+import com.google.protobuf.ByteString
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.provenance.attribute.v1.Attribute
+import io.provenance.digitalcurrency.consortium.TestContainer
+import io.provenance.digitalcurrency.consortium.config.BankClientProperties
+import io.provenance.digitalcurrency.consortium.config.EventStreamProperties
+import io.provenance.digitalcurrency.consortium.config.ProvenanceProperties
+import io.provenance.digitalcurrency.consortium.config.ServiceProperties
+import io.provenance.digitalcurrency.consortium.domain.CoinMovementRecord
+import io.provenance.digitalcurrency.consortium.domain.CoinMovementTable
+import io.provenance.digitalcurrency.consortium.extension.toByteArray
+import io.provenance.digitalcurrency.consortium.frameworks.toOutput
+import io.provenance.digitalcurrency.consortium.pbclient.RpcClient
+import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockId
+import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockResponse
+import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.PartSetHeader
+import io.provenance.digitalcurrency.consortium.pbclient.fetchBlock
+import io.provenance.digitalcurrency.consortium.randomTxHash
+import io.provenance.digitalcurrency.consortium.service.PbcService
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
+import java.time.OffsetDateTime
+import java.util.UUID
 
-// @TestContainer
-// class EventStreamConsumerTest(
-//     private val provenanceProperties: ProvenanceProperties,
-//     private val serviceProperties: ServiceProperties
-// ) {
-//     @Autowired
-//     private lateinit var eventStreamProperties: EventStreamProperties
-//     @Autowired
-//     private lateinit var bankClientProperties: BankClientProperties
-//
-//     @MockBean
-//     private lateinit var eventStreamFactory: EventStreamFactory
-//     @MockBean
-//     private lateinit var pbcServiceMock: PbcService
-//     @MockBean
-//     private lateinit var rpcClientMock: RpcClient
-//
-//     class EventStreamConsumerWrapper(
-//         eventStreamFactory: EventStreamFactory,
-//         pbcService: PbcService,
-//         rpcClient: RpcClient,
-//         bankClientProperties: BankClientProperties,
-//         eventStreamProperties: EventStreamProperties,
-//         provenanceProperties: ProvenanceProperties,
-//         serviceProperties: ServiceProperties
-//     ) : EventStreamConsumer(
-//         eventStreamFactory,
-//         pbcService,
-//         rpcClient,
-//         bankClientProperties,
-//         eventStreamProperties,
-//         provenanceProperties,
-//         serviceProperties
-//     ) {
-//
-//         fun testHandleCoinMovementEvents(
-//             burns: Burns = listOf(),
-//             withdraws: Withdraws = listOf(),
-//             markerTransfers: MarkerTransfers = listOf(),
-//             mints: Mints = listOf()
-//         ) {
-//             super.handleEvents(0L, burns, withdraws, markerTransfers, mints)
-//         }
-//
-//         fun testHandleEvents(
-//             mints: Mints = listOf(),
-//             burns: Burns = listOf(),
-//             redemptions: Redemptions = listOf(),
-//             transfers: Transfers = listOf()
-//         ) {
-//             super.handleEvents(0L, mints, burns, redemptions, transfers)
-//         }
-//
-//     private lateinit var eventStreamConsumerWrapper: EventStreamConsumerWrapper
-//
-//     @BeforeEach
-//     fun beforeEach() {
-//         reset(eventStreamFactory)
-//         reset(pbcServiceMock)
-//         reset(rpcClientMock)
-//
-//         transaction { CoinMovementRecord.all().map { it.delete() } }
-//     }
-//
-//     @BeforeAll
-//     fun beforeAll() {
-//         eventStreamConsumerWrapper = EventStreamConsumerWrapper(
-//             eventStreamFactory,
-//             pbcServiceMock,
-//             rpcClientMock,
-//             bankClientProperties,
-//             eventStreamProperties,
-//             provenanceProperties,
-//             serviceProperties
-//         )
-//     }
-//
-//     @Test
-//     fun `coinMovement - events without bank parties are ignored`() {
-//         val blockTime = OffsetDateTime.now()
-//         val blockResponse = BlockResponse(
-//             block = Block(
-//                 header = BlockHeader(0, blockTime.toString()),
-//                 data = BlockData(emptyList()),
-//             ),
-//             blockId = BlockId("", PartSetHeader(0, ""))
-//         )
-//         val mint = Mint(
-//             txHash = randomTxHash(),
-//             toAddress = "toAddr",
-//             administrator = "adminAddr",
-//             coins = "100",
-//             denom = "usdf.c",
-//             height = 0,
-//         )
-//         val transfer = MarkerTransfer(
-//             txHash = randomTxHash(),
-//             toAddress = "toAddr",
-//             fromAddress = "fromAddr",
-//             amount = "100",
-//             denom = "usdf.c",
-//             height = 0,
-//         )
-//         val withdraw = Withdraw(
-//             txHash = randomTxHash(),
-//             toAddress = "toAddr",
-//             administrator = "adminAddr",
-//             coins = "100",
-//             denom = "usdf.c",
-//             height = 0,
-//         )
-//
-//         whenever(pbcServiceMock.getAttributes(any())).thenReturn(emptyList())
-//
-//         mockkStatic(RpcClient::fetchBlock)
-//         every { rpcClientMock.fetchBlock(0) } returns blockResponse
-//
-//         eventStreamConsumerWrapper.testHandleEvents(
-//             mints = listOf(mint),
-//             withdraws = listOf(withdraw),
-//             markerTransfers = listOf(transfer),
-//         )
-//
-//         Assertions.assertEquals(0, transaction { CoinMovementRecord.all().count() })
-//     }
-//
-//     @Test
-//     fun `coinMovement - mints, withraws, and transfers for bank parties are persisted`() {
-//         val blockTime = OffsetDateTime.now()
-//         val blockResponse = BlockResponse(
-//             block = Block(
-//                 header = BlockHeader(0, blockTime.toString()),
-//                 data = BlockData(emptyList()),
-//             ),
-//             blockId = BlockId("", PartSetHeader(0, ""))
-//         )
-//         val mint = Mint(
-//             txHash = randomTxHash(),
-//             toAddress = "toAddr",
-//             administrator = "adminAddr",
-//             coins = "100",
-//             denom = "usdf.c",
-//             height = 0,
-//         )
-//         val transfer = MarkerTransfer(
-//             txHash = randomTxHash(),
-//             toAddress = "toAddr",
-//             fromAddress = "fromAddr",
-//             amount = "100",
-//             denom = "usdf.c",
-//             height = 0,
-//         )
-//         val withdraw = Withdraw(
-//             txHash = randomTxHash(),
-//             toAddress = "toAddr",
-//             administrator = "adminAddr",
-//             coins = "100",
-//             denom = "usdf.c",
-//             height = 0,
-//         )
-//
-//         whenever(pbcServiceMock.getAttributes(any()))
-//             .thenReturn(
-//                 listOf(
-//                     Attribute.newBuilder()
-//                         .setName(bankClientProperties.kycTagName)
-//                         .setValue(ByteString.copyFrom(UUID.randomUUID().toByteArray()))
-//                         .build()
-//                 )
-//             )
-//
-//         mockkStatic(RpcClient::fetchBlock)
-//         every { rpcClientMock.fetchBlock(0) } returns blockResponse
-//
-//         eventStreamConsumerWrapper.testHandleEvents(
-//             mints = listOf(mint),
-//             withdraws = listOf(withdraw),
-//             markerTransfers = listOf(transfer),
-//         )
-//
-//         Assertions.assertEquals(3, transaction { CoinMovementRecord.all().count() })
-//     }
-//
-//     @Test
-//     fun `coinMovement - block reentry is ignored`() {
-//         val blockTime = OffsetDateTime.now()
-//         val blockResponse = BlockResponse(
-//             block = Block(
-//                 header = BlockHeader(0, blockTime.toString()),
-//                 data = BlockData(emptyList()),
-//             ),
-//             blockId = BlockId("", PartSetHeader(0, ""))
-//         )
-//         val mint = Mint(
-//             txHash = randomTxHash(),
-//             toAddress = "toAddr",
-//             administrator = "adminAddr",
-//             coins = "100",
-//             denom = "usdf.c",
-//             height = 0,
-//         )
-//         val transfer = MarkerTransfer(
-//             txHash = randomTxHash(),
-//             toAddress = "toAddr",
-//             fromAddress = "fromAddr",
-//             amount = "100",
-//             denom = "usdf.c",
-//             height = 0,
-//         )
-//         val withdraw = Withdraw(
-//             txHash = randomTxHash(),
-//             toAddress = "toAddr",
-//             administrator = "adminAddr",
-//             coins = "100",
-//             denom = "usdf.c",
-//             height = 0,
-//         )
-//
-//         whenever(pbcServiceMock.getAttributes(any()))
-//             .thenReturn(
-//                 listOf(
-//                     Attribute.newBuilder()
-//                         .setName(bankClientProperties.kycTagName)
-//                         .setValue(ByteString.copyFrom(UUID.randomUUID().toByteArray()))
-//                         .build()
-//                 )
-//             )
-//
-//         mockkStatic(RpcClient::fetchBlock)
-//         every { rpcClientMock.fetchBlock(0) } returns blockResponse
-//
-//         eventStreamConsumerWrapper.testHandleEvents(
-//             mints = listOf(mint),
-//             withdraws = listOf(withdraw),
-//             markerTransfers = listOf(transfer),
-//         )
-//
-//         Assertions.assertEquals(3, transaction { CoinMovementRecord.all().count() })
-//
-//         eventStreamConsumerWrapper.testHandleEvents(
-//             mints = listOf(mint),
-//             withdraws = listOf(withdraw),
-//             markerTransfers = listOf(transfer),
-//         )
-//         eventStreamConsumerWrapper.testHandleEvents(
-//             mints = listOf(mint),
-//             withdraws = listOf(withdraw),
-//             markerTransfers = listOf(transfer),
-//         )
-//         eventStreamConsumerWrapper.testHandleEvents(
-//             mints = listOf(mint),
-//             withdraws = listOf(withdraw),
-//             markerTransfers = listOf(transfer),
-//         )
-//
-//         Assertions.assertEquals(3, transaction { CoinMovementRecord.all().count() })
-//     }
-// }
-//
+@TestContainer
+class EventStreamConsumerTest {
+    @Autowired
+    private lateinit var eventStreamProperties: EventStreamProperties
+    @Autowired
+    private lateinit var bankClientProperties: BankClientProperties
+    @Autowired
+    private lateinit var provenanceProperties: ProvenanceProperties
+    @Autowired
+    private lateinit var serviceProperties: ServiceProperties
+
+    @MockBean
+    lateinit var eventStreamFactory: EventStreamFactory
+    @MockBean
+    lateinit var pbcServiceMock: PbcService
+    @MockBean
+    private lateinit var rpcClientMock: RpcClient
+
+    private lateinit var eventStreamConsumer: EventStreamConsumer
+
+    @BeforeEach
+    fun beforeEach() {
+        reset(eventStreamFactory)
+        reset(pbcServiceMock)
+        reset(rpcClientMock)
+
+        transaction { CoinMovementRecord.all().map { it.delete() } }
+
+        whenever(pbcServiceMock.managerAddress)
+            .thenReturn("managerAddr")
+    }
+
+    @BeforeAll
+    fun beforeAll() {
+        eventStreamConsumer = EventStreamConsumer(
+            eventStreamFactory,
+            pbcServiceMock,
+            rpcClientMock,
+            bankClientProperties,
+            eventStreamProperties,
+            serviceProperties,
+            provenanceProperties,
+        )
+    }
+
+    @Test
+    fun `coinMovement - events without bank parties are ignored`() {
+        val blockTime = OffsetDateTime.now()
+        val blockResponse = BlockResponse(
+            block = Block(
+                header = BlockHeader(0, blockTime.toString()),
+                data = BlockData(emptyList()),
+            ),
+            blockId = BlockId("", PartSetHeader(0, ""))
+        )
+        val mint = Mint(
+            amount = "100",
+            denom = "bankcoin.1",
+            withdrawDenom = "dccbank.coin",
+            withdrawAddress = "toAddr",
+            memberId = "bank",
+            height = 0,
+            txHash = randomTxHash(),
+        )
+        val burn = Transfer(
+            contractAddress = "",
+            amount = "100",
+            denom = "dccbank.coin",
+            recipient = pbcServiceMock.managerAddress,
+            sender = "adminAddr",
+            height = 0,
+            txHash = randomTxHash(),
+        )
+        val transfer = MarkerTransfer(
+            toAddress = "toAddr",
+            fromAddress = "fromAddr",
+            amount = "100",
+            denom = "dccbank.coin",
+            height = 0,
+            txHash = randomTxHash(),
+        )
+
+        whenever(pbcServiceMock.getAttributeByTagName(any(), eq(bankClientProperties.kycTagName)))
+            .thenReturn(null)
+
+        mockkStatic(RpcClient::fetchBlock)
+        every { rpcClientMock.fetchBlock(0) } returns blockResponse
+
+        eventStreamConsumer.handleCoinMovementEvents(
+            blockHeight = blockResponse.block.header.height,
+            mints = listOf(mint),
+            burns = listOf(burn),
+            transfers = listOf(transfer),
+        )
+
+        Assertions.assertEquals(0, transaction { CoinMovementRecord.all().count() })
+    }
+
+    @Test
+    fun `coinMovement - mints, burns, and transfers for bank parties are persisted`() {
+        val blockTime = OffsetDateTime.now()
+        val blockResponse = BlockResponse(
+            block = Block(
+                header = BlockHeader(0, blockTime.toString()),
+                data = BlockData(emptyList()),
+            ),
+            blockId = BlockId("", PartSetHeader(0, ""))
+        )
+        val mint = Mint(
+            amount = "100",
+            denom = "bankcoin.1",
+            withdrawDenom = "dccbank.coin",
+            withdrawAddress = "toAddr",
+            memberId = "bank",
+            height = 0,
+            txHash = randomTxHash(),
+        )
+        val burn = Transfer(
+            contractAddress = "",
+            amount = "100",
+            denom = "dccbank.coin",
+            recipient = pbcServiceMock.managerAddress,
+            sender = "adminAddr",
+            height = 0,
+            txHash = randomTxHash(),
+        )
+        val transfer = MarkerTransfer(
+            toAddress = "toAddr",
+            fromAddress = "fromAddr",
+            amount = "100",
+            denom = "dccbank.coin",
+            height = 0,
+            txHash = randomTxHash(),
+        )
+
+        whenever(pbcServiceMock.getAttributeByTagName(any(), eq(bankClientProperties.kycTagName)))
+            .thenReturn(
+                Attribute.newBuilder()
+                    .setName(bankClientProperties.kycTagName)
+                    .setValue(ByteString.copyFrom(UUID.randomUUID().toByteArray()))
+                    .build()
+            )
+
+        mockkStatic(RpcClient::fetchBlock)
+        every { rpcClientMock.fetchBlock(0) } returns blockResponse
+
+        eventStreamConsumer.handleCoinMovementEvents(
+            blockHeight = blockResponse.block.header.height,
+            mints = listOf(mint),
+            burns = listOf(burn),
+            transfers = listOf(transfer),
+        )
+
+        Assertions.assertEquals(3, transaction { CoinMovementRecord.all().count() })
+    }
+
+    @Test
+    fun `coinMovement - block reentry is ignored`() {
+        val blockTime = OffsetDateTime.now()
+        val blockResponse = BlockResponse(
+            block = Block(
+                header = BlockHeader(0, blockTime.toString()),
+                data = BlockData(emptyList()),
+            ),
+            blockId = BlockId("", PartSetHeader(0, ""))
+        )
+        val mint = Mint(
+            amount = "100",
+            denom = "bankcoin.1",
+            withdrawDenom = "dccbank.coin",
+            withdrawAddress = "toAddr",
+            memberId = "bank",
+            height = 0,
+            txHash = randomTxHash(),
+        )
+        val burn = Transfer(
+            contractAddress = "",
+            amount = "100",
+            denom = "dccbank.coin",
+            recipient = pbcServiceMock.managerAddress,
+            sender = "adminAddr",
+            height = 0,
+            txHash = randomTxHash(),
+        )
+        val transfer = MarkerTransfer(
+            toAddress = "toAddr",
+            fromAddress = "fromAddr",
+            amount = "100",
+            denom = "dccbank.coin",
+            height = 0,
+            txHash = randomTxHash(),
+        )
+
+        whenever(pbcServiceMock.getAttributeByTagName(any(), eq(bankClientProperties.kycTagName)))
+            .thenReturn(
+                Attribute.newBuilder()
+                    .setName(bankClientProperties.kycTagName)
+                    .setValue(ByteString.copyFrom(UUID.randomUUID().toByteArray()))
+                    .build()
+            )
+
+        mockkStatic(RpcClient::fetchBlock)
+        every { rpcClientMock.fetchBlock(0) } returns blockResponse
+
+        eventStreamConsumer.handleCoinMovementEvents(
+            blockHeight = blockResponse.block.header.height,
+            mints = listOf(mint),
+            burns = listOf(burn),
+            transfers = listOf(transfer),
+        )
+
+        Assertions.assertEquals(3, transaction { CoinMovementRecord.all().count() })
+
+        eventStreamConsumer.handleCoinMovementEvents(
+            blockHeight = blockResponse.block.header.height,
+            mints = listOf(mint),
+            burns = listOf(burn),
+            transfers = listOf(transfer),
+        )
+        eventStreamConsumer.handleCoinMovementEvents(
+            blockHeight = blockResponse.block.header.height,
+            mints = listOf(mint),
+            burns = listOf(burn),
+            transfers = listOf(transfer),
+        )
+        eventStreamConsumer.handleCoinMovementEvents(
+            blockHeight = blockResponse.block.header.height,
+            mints = listOf(mint),
+            burns = listOf(burn),
+            transfers = listOf(transfer),
+        )
+
+        Assertions.assertEquals(3, transaction { CoinMovementRecord.all().count() })
+    }
+
+    @Test
+    fun `coinMovement - batched messages in one tx are persisted`() {
+        val blockTime = OffsetDateTime.now()
+        val blockResponse = BlockResponse(
+            block = Block(
+                header = BlockHeader(0, blockTime.toString()),
+                data = BlockData(emptyList()),
+            ),
+            blockId = BlockId("", PartSetHeader(0, ""))
+        )
+        val mint = Mint(
+            amount = "100",
+            denom = "bankcoin.1",
+            withdrawDenom = "dccbank.coin",
+            withdrawAddress = "toAddr",
+            memberId = "bank",
+            height = 0,
+            txHash = "tx1",
+        )
+        val burn = Transfer(
+            contractAddress = "",
+            amount = "100",
+            denom = "dccbank.coin",
+            recipient = pbcServiceMock.managerAddress,
+            sender = "adminAddr",
+            height = 0,
+            txHash = "tx1",
+        )
+        val transfer = MarkerTransfer(
+            toAddress = "toAddr",
+            fromAddress = "fromAddr",
+            amount = "100",
+            denom = "dccbank.coin",
+            height = 0,
+            txHash = "tx1",
+        )
+
+        whenever(pbcServiceMock.getAttributeByTagName(any(), eq(bankClientProperties.kycTagName)))
+            .thenReturn(
+                Attribute.newBuilder()
+                    .setName(bankClientProperties.kycTagName)
+                    .setValue(ByteString.copyFrom(UUID.randomUUID().toByteArray()))
+                    .build()
+            )
+
+        mockkStatic(RpcClient::fetchBlock)
+        every { rpcClientMock.fetchBlock(0) } returns blockResponse
+
+        eventStreamConsumer.handleCoinMovementEvents(
+            blockHeight = blockResponse.block.header.height,
+            mints = listOf(mint),
+            burns = listOf(burn),
+            transfers = listOf(transfer),
+        )
+
+        Assertions.assertEquals(3, transaction { CoinMovementRecord.all().count() })
+        Assertions.assertEquals(
+            listOf("tx1-0", "tx1-1", "tx1-2"),
+            transaction { CoinMovementRecord.all().toList() }.map { it.txHash() }.sorted(),
+        )
+    }
+
+    @Test
+    fun `coinMovement - check v1 vs v2 output`() {
+        transaction {
+            CoinMovementRecord.insert(
+                txHash = "abc",
+                fromAddress = "fromAddress",
+                fromAddressBankUuid = null,
+                toAddress = "toAddress",
+                toAddressBankUuid = null,
+                blockHeight = 0,
+                blockTime = OffsetDateTime.now(),
+                amount = "100",
+                denom = "coin",
+                type = "MINT",
+            )
+            CoinMovementRecord.insert(
+                txHash = "abc-0",
+                fromAddress = "fromAddress",
+                fromAddressBankUuid = null,
+                toAddress = "toAddress",
+                toAddressBankUuid = null,
+                blockHeight = 0,
+                blockTime = OffsetDateTime.now(),
+                amount = "100",
+                denom = "coin",
+                type = "MINT",
+            )
+        }
+
+        transaction {
+            CoinMovementTable.update { it[legacyTxHash] = "abc" }
+        }
+
+        transaction {
+            CoinMovementRecord.insert(
+                txHash = "xyz-0",
+                fromAddress = "fromAddress",
+                fromAddressBankUuid = null,
+                toAddress = "toAddress",
+                toAddressBankUuid = null,
+                blockHeight = 0,
+                blockTime = OffsetDateTime.now(),
+                amount = "100",
+                denom = "coin",
+                type = "MINT",
+            )
+            CoinMovementRecord.insert(
+                txHash = "xyz-0",
+                fromAddress = "fromAddress",
+                fromAddressBankUuid = null,
+                toAddress = "toAddress",
+                toAddressBankUuid = null,
+                blockHeight = 0,
+                blockTime = OffsetDateTime.now(),
+                amount = "100",
+                denom = "coin",
+                type = "MINT",
+            )
+            CoinMovementRecord.insert(
+                txHash = "xyz-1",
+                fromAddress = "fromAddress",
+                fromAddressBankUuid = null,
+                toAddress = "toAddress",
+                toAddressBankUuid = null,
+                blockHeight = 0,
+                blockTime = OffsetDateTime.now(),
+                amount = "100",
+                denom = "coin",
+                type = "MINT",
+            )
+            CoinMovementRecord.insert(
+                txHash = "xyz-2",
+                fromAddress = "fromAddress",
+                fromAddressBankUuid = null,
+                toAddress = "toAddress",
+                toAddressBankUuid = null,
+                blockHeight = 0,
+                blockTime = OffsetDateTime.now(),
+                amount = "100",
+                denom = "coin",
+                type = "MINT",
+            )
+        }
+
+        Assertions.assertEquals(5, transaction { CoinMovementRecord.all().count() })
+        Assertions.assertArrayEquals(
+            listOf("abc", "abc-0", "xyz-0", "xyz-1", "xyz-2").toTypedArray(),
+            transaction { CoinMovementRecord.all().toList() }.map { it._txHashV2.value }.sorted().toTypedArray(),
+        )
+        Assertions.assertArrayEquals(
+            listOf("abc", "abc", "xyz-0", "xyz-1", "xyz-2").toTypedArray(),
+            transaction { CoinMovementRecord.all().toList() }.toOutput().transactions.map { it.txId }.sorted().toTypedArray(),
+        )
+    }
+}


### PR DESCRIPTION
Makes some small improvements to the coin movement code.

- Fixes an existing known bug where TXs containing more than one coin movement event, subsequent events would be skipped due to them all having the same hash. I corrected this is such a way that if we were to reset NYCB's bookmark, it would dedupe existing records correctly and also still return the `txId` with the same string we returned to them historically so as to correctly maintain their primary key usage.
- Moves `findAttributes` calls to `findAttributeByName`.

## Tests
- [ ] on develop read the testnet stream then move back to this branch and reset the stream. Verify database records. 