### PR TITLE
Fixes #47 - contract address attribute name change

### DIFF
--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/stream/Events.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/stream/Events.kt
@@ -1,7 +1,7 @@
 package io.provenance.digitalcurrency.consortium.stream
 
 private const val ATTRIBUTE_ACTION = "action"
-private const val ATTRIBUTE_CONTRACT_ADDRESS = "contract_address"
+private const val ATTRIBUTE_CONTRACT_ADDRESS = "_contract_address"
 private const val ATTRIBUTE_AMOUNT = "amount"
 private const val ATTRIBUTE_DENOM = "denom"
 private const val ATTRIBUTE_FROM = "from_address"
@@ -98,7 +98,6 @@ fun EventBatch.burns(contractAddress: String): Burns =
 typealias Burns = List<Burn>
 
 data class Burn(
-    val contractAddress: String,
     val amount: String,
     val denom: String,
     val memberId: String,
@@ -108,7 +107,6 @@ data class Burn(
 
 private fun StreamEvent.toBurn(): Burn =
     Burn(
-        contractAddress = getAttribute(ATTRIBUTE_CONTRACT_ADDRESS),
         amount = getAttribute(ATTRIBUTE_AMOUNT),
         denom = getAttribute(ATTRIBUTE_DENOM),
         memberId = getAttribute(ATTRIBUTE_MEMBER_ID),
@@ -129,7 +127,6 @@ fun EventBatch.redemptions(contractAddress: String): Redemptions =
 typealias Redemptions = List<Redemption>
 
 data class Redemption(
-    val contractAddress: String,
     val amount: String,
     val reserveDenom: String,
     val memberId: String,
@@ -139,7 +136,6 @@ data class Redemption(
 
 private fun StreamEvent.toRedemption(): Redemption =
     Redemption(
-        contractAddress = getAttribute(ATTRIBUTE_CONTRACT_ADDRESS),
         amount = getAttribute(ATTRIBUTE_AMOUNT),
         reserveDenom = getAttribute(ATTRIBUTE_RESERVE_DENOM),
         memberId = getAttribute(ATTRIBUTE_MEMBER_ID),
@@ -160,7 +156,6 @@ fun EventBatch.transfers(contractAddress: String): Transfers =
 typealias Transfers = List<Transfer>
 
 data class Transfer(
-    val contractAddress: String,
     val amount: String,
     val denom: String,
     val sender: String,
@@ -171,7 +166,6 @@ data class Transfer(
 
 private fun StreamEvent.toTransfer(): Transfer =
     Transfer(
-        contractAddress = getAttribute(ATTRIBUTE_CONTRACT_ADDRESS),
         amount = getAttribute(ATTRIBUTE_AMOUNT),
         denom = getAttribute(ATTRIBUTE_DENOM),
         sender = getAttribute(ATTRIBUTE_SENDER),

--- a/service/src/main/resources/application-development.properties
+++ b/service/src/main/resources/application-development.properties
@@ -1,6 +1,6 @@
 service.environment=development
 service.manager_key=${MANAGER_KEY}
-service.dcc_denom=centiusdx
+service.dcc_denom=usdf.local
 
 # DB
 database.prefix=jdbc
@@ -20,7 +20,7 @@ springfox.documentation.swagger.v2.host=DEFAULT
 provenance.chain_id=chain-local
 provenance.main_net=false
 provenance.grpc_channel_url=http://localhost:9090
-provenance.contract_address=tp18vd8fpwxzck93qlwghaj6arh4p7c5n89x8kskz
+provenance.contract_address=tp14hj2tavq8fpesdwxxcu44rty3hh90vhuz3ljwv
 
 # Event Stream
 event_stream.connect.delay.ms=10000
@@ -35,7 +35,7 @@ event.stream.epoch=0
 # 3rd party bank middleware
 # bank.uri=https://self-signed.badssl.com
 bank.uri=http://localhost:8888/service-omnibus-ops
-bank.kyc_tag_name=dccbank1.kyc.pb
+bank.kyc_tag_name=bank1.kyc.pb
 bank.denom=dccbank1.coin
 
 coroutine.num_workers=1
@@ -44,4 +44,4 @@ coroutine.polling_delay_ms=5000
 coin.movement.polling_delay_ms=60000
 balance.report.polling_delay_ms=10000
 balance.report.page_size=7
-balance.report.addresses_whitelist=tp1zhde9cvckxk2uc9m2kjstj9f86uv4zwnaz57z4
+balance.report.addresses_whitelist=tp14hj2tavq8fpesdwxxcu44rty3hh90vhuz3ljwv

--- a/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/TestUtil.kt
+++ b/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/TestUtil.kt
@@ -81,7 +81,6 @@ fun getPendingTransactionResponse(txHash: String): ServiceOuterClass.GetTxRespon
 
 fun getTransferEvent(txHash: String = randomTxHash(), toAddress: String = TEST_MEMBER_ADDRESS, denom: String) =
     Transfer(
-        contractAddress = TEST_MEMBER_ADDRESS,
         amount = DEFAULT_AMOUNT.toString(),
         denom = denom,
         sender = TEST_ADDRESS,
@@ -92,7 +91,6 @@ fun getTransferEvent(txHash: String = randomTxHash(), toAddress: String = TEST_M
 
 fun getBurnEvent(txHash: String = randomTxHash(), denom: String) =
     Burn(
-        contractAddress = TEST_MEMBER_ADDRESS,
         amount = DEFAULT_AMOUNT.toString(),
         denom = denom,
         memberId = TEST_MEMBER_ADDRESS,

--- a/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
+++ b/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
@@ -320,7 +320,6 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
                 blockHeight = 50,
                 burns = listOf(
                     Burn(
-                        contractAddress = TEST_ADDRESS,
                         denom = "dummyDenom",
                         amount = DEFAULT_AMOUNT.toString(),
                         memberId = TEST_ADDRESS,


### PR DESCRIPTION
I don't believe there is a need for backwards support of the old attribute name `contract_address` - I have not seen it on any of the events I have been monitoring in v1.7.*.