### PR TITLE
Fix marker transfer filter denom

### DIFF
--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumer.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumer.kt
@@ -174,7 +174,7 @@ class EventStreamConsumer(
 
         // general coin transfers outside of the SC are tracked require the EventMarkerTransfer event
         val filteredTransfers = transfers.filter { it.fromAddress.isNotEmpty() && it.toAddress.isNotEmpty() }
-            .filter { it.denom == bankClientProperties.denom }
+            .filter { it.denom == serviceProperties.dccDenom }
             .mapNotNull { event ->
                 log.debug("MarkerTransfer - tx: ${event.txHash} from: ${event.fromAddress} to: ${event.toAddress} amount: ${event.amount} denom: ${event.denom}")
 

--- a/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
+++ b/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
@@ -114,7 +114,7 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
 
         private val transfer = getMarkerTransferEvent(
             toAddress = TEST_MEMBER_ADDRESS,
-            denom = bankClientProperties.denom
+            denom = serviceProperties.dccDenom
         )
 
         @Test
@@ -250,7 +250,7 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
                     getMarkerTransferEvent(
                         txHash = "tx1",
                         toAddress = TEST_MEMBER_ADDRESS,
-                        denom = bankClientProperties.denom
+                        denom = serviceProperties.dccDenom
                     )
                 ),
             )


### PR DESCRIPTION
The bank denom was wrongfully being used. I realized this after looking at the spreadsheets that Jim shared with us. There are events that had multiple transfers, which is what the last PR handled, but still it didn't make sense that they stopped seeing all marker transfers for so long, this was due to the filter that I added a while back.

The underlying problem was that when I test this against prod, I seed my environment with the needed env vars. I was wrongfully mixing up the dcc denom and bank denom fields.