### PR TITLE
issue84 redeem and burn logship and burn rename to redeem

### DIFF
--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/domain/CoinMovement.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/domain/CoinMovement.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 const val MINT = "MINT"
 const val TRANSFER = "TRANSFER"
 const val REDEEM_BURN = "REDEEM_BURN"
-const val DEPOSIT = "DEPOSIT"
+const val REDEEM = "REDEEM"
 
 abstract class StringEntityClass<out E : Entity<String>>(table: IdTable<String>, entityType: Class<E>? = null) : EntityClass<String, E>(table, entityType)
 

--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/domain/CoinMovement.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/domain/CoinMovement.kt
@@ -11,7 +11,8 @@ import java.util.UUID
 
 const val MINT = "MINT"
 const val TRANSFER = "TRANSFER"
-const val BURN = "BURN"
+const val REDEEM_BURN = "REDEEM_BURN"
+const val DEPOSIT = "DEPOSIT"
 
 abstract class StringEntityClass<out E : Entity<String>>(table: IdTable<String>, entityType: Class<E>? = null) : EntityClass<String, E>(table, entityType)
 

--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumer.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumer.kt
@@ -7,11 +7,11 @@ import io.provenance.digitalcurrency.consortium.config.ServiceProperties
 import io.provenance.digitalcurrency.consortium.config.logger
 import io.provenance.digitalcurrency.consortium.domain.AddressRegistrationRecord
 import io.provenance.digitalcurrency.consortium.domain.CoinMovementRecord
-import io.provenance.digitalcurrency.consortium.domain.DEPOSIT
 import io.provenance.digitalcurrency.consortium.domain.EventStreamRecord
 import io.provenance.digitalcurrency.consortium.domain.MINT
 import io.provenance.digitalcurrency.consortium.domain.MarkerTransferRecord
 import io.provenance.digitalcurrency.consortium.domain.MigrationRecord
+import io.provenance.digitalcurrency.consortium.domain.REDEEM
 import io.provenance.digitalcurrency.consortium.domain.REDEEM_BURN
 import io.provenance.digitalcurrency.consortium.domain.TRANSFER
 import io.provenance.digitalcurrency.consortium.domain.TxRequestViewRecord
@@ -253,7 +253,7 @@ class EventStreamConsumer(
                     blockTime = OffsetDateTime.parse(block.header.time),
                     amount = wrapper.transfer.amount,
                     denom = wrapper.transfer.denom,
-                    type = DEPOSIT,
+                    type = REDEEM,
                 )
             }
 

--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumer.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumer.kt
@@ -166,6 +166,7 @@ class EventStreamConsumer(
 
                 // persist a record of this transaction if the to address has this bank's attribute, the from address will be the SC address
                 if (toAddressBankUuid != null) {
+                    // TODO - handle mint directly to member bank
                     MintWrapper(event, toAddressBankUuid)
                 } else {
                     null

--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/stream/Events.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/stream/Events.kt
@@ -5,6 +5,7 @@ private const val ATTRIBUTE_CODE_ID = "code_id"
 private const val ATTRIBUTE_CONTRACT_ADDRESS = "_contract_address"
 private const val ATTRIBUTE_AMOUNT = "amount"
 private const val ATTRIBUTE_DENOM = "denom"
+private const val ATTRIBUTE_RESERVE_DENOM = "reserve_denom"
 private const val ATTRIBUTE_FROM = "from_address"
 private const val ATTRIBUTE_WITHDRAW_DENOM = "withdraw_denom"
 private const val ATTRIBUTE_WITHDRAW_ADDRESS = "withdraw_address"
@@ -15,6 +16,7 @@ private const val ATTRIBUTE_RECIPIENT = "recipient"
 
 private const val MINT_ACTION = "mint"
 private const val TRANSFER_ACTION = "transfer"
+private const val REDEEM_BURN_ACTION = "redeem_and_burn"
 
 const val WASM_EVENT = "wasm"
 const val MARKER_TRANSFER_EVENT = "provenance.marker.v1.EventMarkerTransfer"
@@ -100,6 +102,36 @@ private fun StreamEvent.toMint(): Mint =
         memberId = getAttribute(ATTRIBUTE_MEMBER_ID),
         height = height,
         txHash = txHash
+    )
+
+fun EventBatch.redeemBurns(contractAddress: String): RedeemBurns =
+    events
+        .filter { event ->
+            val action = event.getAttribute(ATTRIBUTE_ACTION)
+            val contractAddressAttr = event.getAttribute(ATTRIBUTE_CONTRACT_ADDRESS)
+            event.eventType == WASM_EVENT && action == REDEEM_BURN_ACTION && contractAddress == contractAddressAttr
+        }
+        .map { event -> event.toRedeemBurn() }
+
+typealias RedeemBurns = List<RedeemBurn>
+
+data class RedeemBurn(
+    val amount: String,
+    val denom: String,
+    val memberId: String,
+    val reserveDenom: String,
+    val height: Long,
+    val txHash: String
+)
+
+private fun StreamEvent.toRedeemBurn(): RedeemBurn =
+    RedeemBurn(
+        amount = getAttribute(ATTRIBUTE_AMOUNT),
+        denom = getAttribute(ATTRIBUTE_DENOM),
+        memberId = getAttribute(ATTRIBUTE_MEMBER_ID),
+        reserveDenom = getAttribute(ATTRIBUTE_RESERVE_DENOM),
+        height = height,
+        txHash = txHash,
     )
 
 fun EventBatch.transfers(contractAddress: String): Transfers =

--- a/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/TestUtil.kt
+++ b/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/TestUtil.kt
@@ -3,6 +3,7 @@ package io.provenance.digitalcurrency.consortium
 import io.provenance.digitalcurrency.consortium.stream.MarkerTransfer
 import io.provenance.digitalcurrency.consortium.stream.Migration
 import io.provenance.digitalcurrency.consortium.stream.Mint
+import io.provenance.digitalcurrency.consortium.stream.RedeemBurn
 import io.provenance.digitalcurrency.consortium.stream.Transfer
 import java.math.BigInteger
 import kotlin.random.Random
@@ -32,6 +33,16 @@ fun getTransferEvent(txHash: String = randomTxHash(), toAddress: String = TEST_M
         recipient = toAddress,
         height = 50,
         txHash = txHash
+    )
+
+fun getRedeemBurnEvent(txHash: String = randomTxHash(), memberId: String = TEST_MEMBER_ADDRESS, denom: String, reserveDenom: String) =
+    RedeemBurn(
+        amount = DEFAULT_AMOUNT.toString(),
+        denom = denom,
+        memberId = memberId,
+        reserveDenom = reserveDenom,
+        height = 50,
+        txHash = txHash,
     )
 
 fun getMarkerTransferEvent(txHash: String = randomTxHash(), toAddress: String = TEST_MEMBER_ADDRESS, denom: String) =

--- a/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
+++ b/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
@@ -106,7 +106,7 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
             bankDenom = bankClientProperties.denom
         )
 
-        private val deposit = getTransferEvent(
+        private val redeem = getTransferEvent(
             toAddress = TEST_MEMBER_ADDRESS,
             denom = serviceProperties.dccDenom
         )
@@ -139,7 +139,7 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                transfers = listOf(deposit),
+                transfers = listOf(redeem),
                 redeemBurns = listOf(redeemBurn.copy(memberId = "someotherbank")),
                 markerTransfers = listOf(transfer),
             )
@@ -148,7 +148,7 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
         }
 
         @Test
-        fun `coinMovement - mints, deposits, redeem+burns and transfers for bank parties are persisted`() {
+        fun `coinMovement - mints, redeems, redeem+burns and transfers for bank parties are persisted`() {
             val blockTime = OffsetDateTime.now()
             val blockResponse = BlockResponse(
                 block = Block(
@@ -166,7 +166,7 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                transfers = listOf(deposit),
+                transfers = listOf(redeem),
                 redeemBurns = listOf(redeemBurn),
                 markerTransfers = listOf(transfer),
             )
@@ -193,7 +193,7 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                transfers = listOf(deposit),
+                transfers = listOf(redeem),
                 redeemBurns = listOf(redeemBurn),
                 markerTransfers = listOf(transfer),
             )
@@ -203,21 +203,21 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                transfers = listOf(deposit),
+                transfers = listOf(redeem),
                 redeemBurns = listOf(redeemBurn),
                 markerTransfers = listOf(transfer),
             )
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                transfers = listOf(deposit),
+                transfers = listOf(redeem),
                 redeemBurns = listOf(redeemBurn),
                 markerTransfers = listOf(transfer),
             )
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                transfers = listOf(deposit),
+                transfers = listOf(redeem),
                 redeemBurns = listOf(redeemBurn),
                 markerTransfers = listOf(transfer),
             )

--- a/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
+++ b/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/EventStreamConsumerTest.kt
@@ -25,6 +25,7 @@ import io.provenance.digitalcurrency.consortium.frameworks.toOutput
 import io.provenance.digitalcurrency.consortium.getMarkerTransferEvent
 import io.provenance.digitalcurrency.consortium.getMigrationEvent
 import io.provenance.digitalcurrency.consortium.getMintEvent
+import io.provenance.digitalcurrency.consortium.getRedeemBurnEvent
 import io.provenance.digitalcurrency.consortium.getTransferEvent
 import io.provenance.digitalcurrency.consortium.pbclient.RpcClient
 import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockId
@@ -105,9 +106,15 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
             bankDenom = bankClientProperties.denom
         )
 
-        private val burn = getTransferEvent(
+        private val deposit = getTransferEvent(
             toAddress = TEST_MEMBER_ADDRESS,
             denom = serviceProperties.dccDenom
+        )
+
+        private val redeemBurn = getRedeemBurnEvent(
+            memberId = TEST_MEMBER_ADDRESS,
+            denom = serviceProperties.dccDenom,
+            reserveDenom = bankClientProperties.denom
         )
 
         private val transfer = getMarkerTransferEvent(
@@ -132,15 +139,16 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                burns = listOf(burn),
-                transfers = listOf(transfer),
+                transfers = listOf(deposit),
+                redeemBurns = listOf(redeemBurn.copy(memberId = "someotherbank")),
+                markerTransfers = listOf(transfer),
             )
 
             Assertions.assertEquals(0, transaction { CoinMovementRecord.all().count() })
         }
 
         @Test
-        fun `coinMovement - mints, burns, and transfers for bank parties are persisted`() {
+        fun `coinMovement - mints, deposits, redeem+burns and transfers for bank parties are persisted`() {
             val blockTime = OffsetDateTime.now()
             val blockResponse = BlockResponse(
                 block = Block(
@@ -158,11 +166,12 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                burns = listOf(burn),
-                transfers = listOf(transfer),
+                transfers = listOf(deposit),
+                redeemBurns = listOf(redeemBurn),
+                markerTransfers = listOf(transfer),
             )
 
-            Assertions.assertEquals(3, transaction { CoinMovementRecord.all().count() })
+            Assertions.assertEquals(4, transaction { CoinMovementRecord.all().count() })
         }
 
         @Test
@@ -184,32 +193,36 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                burns = listOf(burn),
-                transfers = listOf(transfer),
+                transfers = listOf(deposit),
+                redeemBurns = listOf(redeemBurn),
+                markerTransfers = listOf(transfer),
             )
 
-            Assertions.assertEquals(3, transaction { CoinMovementRecord.all().count() })
+            Assertions.assertEquals(4, transaction { CoinMovementRecord.all().count() })
 
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                burns = listOf(burn),
-                transfers = listOf(transfer),
+                transfers = listOf(deposit),
+                redeemBurns = listOf(redeemBurn),
+                markerTransfers = listOf(transfer),
             )
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                burns = listOf(burn),
-                transfers = listOf(transfer),
+                transfers = listOf(deposit),
+                redeemBurns = listOf(redeemBurn),
+                markerTransfers = listOf(transfer),
             )
             eventStreamConsumer.handleCoinMovementEvents(
                 blockHeight = blockResponse.block.header.height,
                 mints = listOf(mint),
-                burns = listOf(burn),
-                transfers = listOf(transfer),
+                transfers = listOf(deposit),
+                redeemBurns = listOf(redeemBurn),
+                markerTransfers = listOf(transfer),
             )
 
-            Assertions.assertEquals(3, transaction { CoinMovementRecord.all().count() })
+            Assertions.assertEquals(4, transaction { CoinMovementRecord.all().count() })
         }
 
         @Test
@@ -237,14 +250,22 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
                         bankDenom = bankClientProperties.denom
                     )
                 ),
-                burns = listOf(
+                transfers = listOf(
                     getTransferEvent(
                         txHash = "tx1",
                         toAddress = TEST_MEMBER_ADDRESS,
                         denom = serviceProperties.dccDenom
                     )
                 ),
-                transfers = listOf(
+                redeemBurns = listOf(
+                    getRedeemBurnEvent(
+                        txHash = "tx1",
+                        memberId = TEST_MEMBER_ADDRESS,
+                        denom = serviceProperties.dccDenom,
+                        reserveDenom = bankClientProperties.denom
+                    )
+                ),
+                markerTransfers = listOf(
                     getMarkerTransferEvent(
                         txHash = "tx1",
                         toAddress = TEST_MEMBER_ADDRESS,
@@ -253,9 +274,9 @@ class EventStreamConsumerTest : BaseIntegrationTest() {
                 ),
             )
 
-            Assertions.assertEquals(3, transaction { CoinMovementRecord.all().count() })
+            Assertions.assertEquals(4, transaction { CoinMovementRecord.all().count() })
             Assertions.assertEquals(
-                listOf("tx1-0", "tx1-1", "tx1-2"),
+                listOf("tx1-0", "tx1-1", "tx1-2", "tx1-3"),
                 transaction { CoinMovementRecord.all().toList() }.map { it.txHash() }.sorted(),
             )
         }


### PR DESCRIPTION
* Rename "burn" to "deposit" for transfers from registered accounts back to DCC key pair address
* Add "redeem and burn" event handling as separate coin movement