### PR TITLE
Fix for issue #93 - Update rpc client endpoints for explicit query params

### DIFF
--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/pbclient/RpcClient.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/pbclient/RpcClient.kt
@@ -3,38 +3,38 @@ package io.provenance.digitalcurrency.consortium.pbclient
 import com.fasterxml.jackson.databind.ObjectMapper
 import feign.Feign
 import feign.Logger.Level
+import feign.Param
 import feign.RequestLine
 import feign.jackson.JacksonDecoder
 import feign.jackson.JacksonEncoder
 import feign.slf4j.Slf4jLogger
 import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.AbciInfoMetaResponse
 import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.AbciInfoResponse
-import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockRequest
 import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockResponse
-import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockResultsRequest
 import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockResultsResponse
-import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockchainInfoRequest
 import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockchainInfoResponse
-import io.provenance.digitalcurrency.consortium.stream.RpcRequest
 import io.provenance.digitalcurrency.consortium.stream.RpcResponse
 
 interface RpcClient {
-    @RequestLine("GET /")
-    fun blockchainInfo(request: BlockchainInfoRequest): RpcResponse<BlockchainInfoResponse>
+    @RequestLine("GET /blockchain?minHeight={minHeight}&maxHeight={maxHeight}")
+    fun blockchainInfo(
+        @Param("minHeight") minHeight: Long,
+        @Param("maxHeight") maxHeight: Long,
+    ): RpcResponse<BlockchainInfoResponse>
 
-    @RequestLine("GET /")
-    fun block(request: BlockRequest): RpcResponse<BlockResponse>
+    @RequestLine("GET /block?height={height}")
+    fun block(@Param("height") height: Long): RpcResponse<BlockResponse>
 
-    @RequestLine("GET /")
-    fun blockResults(request: BlockResultsRequest): RpcResponse<BlockResultsResponse>
+    @RequestLine("GET /block_results?height={height}")
+    fun blockResults(@Param("height") height: Long): RpcResponse<BlockResultsResponse>
 
-    @RequestLine("GET /")
-    fun abciInfo(request: RpcRequest = RpcRequest("abci_info")): RpcResponse<AbciInfoMetaResponse>
+    @RequestLine("GET /abci_info")
+    fun abciInfo(): RpcResponse<AbciInfoMetaResponse>
 
     class Builder(
         private val url: String,
         private val objectMapper: ObjectMapper,
-        private val logLevel: String
+        private val logLevel: String,
     ) {
         fun build(): RpcClient = Feign.builder()
             .encoder(JacksonEncoder(objectMapper))
@@ -45,14 +45,21 @@ interface RpcClient {
     }
 }
 
+fun RpcClient.blockchainInfo(minHeight: Int, maxHeight: Int): RpcResponse<BlockchainInfoResponse> =
+    blockchainInfo(minHeight = minHeight.toLong(), maxHeight = maxHeight.toLong())
+
+fun RpcClient.block(height: Int): RpcResponse<BlockResponse> = block(height = height.toLong())
+
+fun RpcClient.blockResults(height: Int): RpcResponse<BlockResultsResponse> = blockResults(height = height.toLong())
+
 fun RpcClient.fetchBlocksWithTransactions(minHeight: Long, maxHeight: Long): List<Long> =
     fetchBlockchainInfo(minHeight, maxHeight).blockMetas.filter { it.numTxs > 0 }.map { it.header.height }
 
 fun RpcClient.fetchBlockchainInfo(minHeight: Long, maxHeight: Long): BlockchainInfoResponse =
-    blockchainInfo(BlockchainInfoRequest(minHeight, maxHeight)).result!!
+    blockchainInfo(minHeight = minHeight, maxHeight = maxHeight).result!!
 
-fun RpcClient.fetchBlock(height: Long): BlockResponse = block(BlockRequest(height)).result!!
+fun RpcClient.fetchBlock(height: Long): BlockResponse = block(height = height).result!!
 
-fun RpcClient.fetchBlockResults(height: Long): BlockResultsResponse = blockResults(BlockResultsRequest(height)).result!!
+fun RpcClient.fetchBlockResults(height: Long): BlockResultsResponse = blockResults(height = height).result!!
 
 fun RpcClient.fetchAbciInfo(): AbciInfoResponse = abciInfo().result!!.response

--- a/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/pbclient/api/rpc/Blockchain.kt
+++ b/service/src/main/kotlin/io/provenance/digitalcurrency/consortium/pbclient/api/rpc/Blockchain.kt
@@ -5,7 +5,7 @@ import io.provenance.digitalcurrency.consortium.stream.BlockHeader
 import io.provenance.digitalcurrency.consortium.stream.RpcRequest
 
 data class BlockchainInfoResponse(
-    val lastHeight: Long,
+    @JsonProperty("last_height") val lastHeight: Long,
     @JsonProperty("block_metas") val blockMetas: List<BlockMeta>
 )
 

--- a/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/RpcClientTest.kt
+++ b/service/src/test/kotlin/io/provenance/digitalcurrency/consortium/stream/RpcClientTest.kt
@@ -1,0 +1,66 @@
+package io.provenance.digitalcurrency.consortium.stream
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.hubspot.jackson.datatype.protobuf.ProtobufModule
+import io.provenance.digitalcurrency.consortium.pbclient.RpcClient
+import io.provenance.digitalcurrency.consortium.pbclient.api.rpc.BlockMeta
+import io.provenance.digitalcurrency.consortium.pbclient.block
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+@Disabled
+class RpcClientTest {
+
+    private val RPC_URI = "http://localhost:26657"
+
+    private val minHeight: Long = 7028100
+    private val maxHeight: Long = 7028121
+
+    val objectMapper: ObjectMapper = ObjectMapper()
+        .registerKotlinModule()
+        .registerModule(JavaTimeModule())
+        .registerModule(ProtobufModule())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+        .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+
+    val rpcClient: RpcClient = RpcClient.Builder(RPC_URI, objectMapper, logLevel = "none").build()
+
+    @Test
+    fun `blockchainInfo request works`() {
+        val blockMetas: List<BlockMeta> =
+            rpcClient.blockchainInfo(minHeight, maxHeight).result!!.blockMetas
+        assertEquals(blockMetas.minOfOrNull { it.header.height }, 7028102L)
+        assertEquals(blockMetas.maxOfOrNull { it.header.height }, 7028121L)
+        assertEquals(blockMetas.count { it.numTxs > 0 }, 2)
+    }
+
+    @Test
+    fun `block params works`() {
+        val height = 7028117
+        assertEquals(rpcClient.block(height).result!!.block.header.height, height.toLong())
+    }
+
+    @Test
+    fun `blockResults params works`() {
+        val height = 7028117
+        val result = rpcClient.blockResults(7028117).result!!
+        assertEquals(result.height, height.toLong())
+        assertEquals(result.txsResults!!.size, 1)
+    }
+
+    @Test
+    fun `abciInfo works`() {
+        assertNotNull(rpcClient.abciInfo().result)
+    }
+}


### PR DESCRIPTION
Fix for issue https://github.com/provenance-io/digital-currency-consortium/issues/93. See https://github.com/FigureTechnologies/provenance-eventstream-legacy-kotlin/pull/2 for details.

Tested by re-enabling `RpcClientTest` and forwarding testnet RPC requests over 26657.